### PR TITLE
Fix mixed tabs/spaces

### DIFF
--- a/powerline_kubernetes/segments.py
+++ b/powerline_kubernetes/segments.py
@@ -9,16 +9,16 @@ class KubernetesSegment(Segment):
             {'contents': u'\U00002388 ', 'highlight_groups': ['kubernetes'], 'divider_highlight_group': 'kubernetes:divider'},
             {'contents': '%s - %s' % (context, namespace), 'highlight_groups': ['kubernetes'], 'divider_highlight_group': 'kubernetes:divider'},
         ]
-	return segments
+        return segments
 
     def __call__(self, pl):
         pl.debug('Running powerline-kubernetes')
 
         self.pl = pl
 
-	try:
+        try:
             context = K8sConfig().current_context
-	    namespace = K8sConfig().namespace
+            namespace = K8sConfig().namespace
         except Exception as e:
             pl.error(e)
             return


### PR DESCRIPTION
I ran into this error when installing powerline-kubernetes using python 3.6
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/powerline/__init__.py", line 392, in get_module_attr
    return getattr(__import__(module, fromlist=(attr,)), attr)
  File "/usr/local/lib/python3.6/site-packages/powerline_kubernetes/__init__.py", line 1, in <module>
    from .segments import kubernetes  # noqa
  File "/usr/local/lib/python3.6/site-packages/powerline_kubernetes/segments.py", line 12
    return segments
```
This PR fixes the tabs in segments.py since most of the file seemed to be using spaces.