### PR TITLE
Fix kubernetes-py module reference

### DIFF
--- a/powerline_kubernetes/segments.py
+++ b/powerline_kubernetes/segments.py
@@ -1,6 +1,6 @@
 # vim:fileencoding=utf-8:noet
 from powerline.segments import Segment, with_docstring
-from kubernetes import K8sConfig
+from kubernetes_py import K8sConfig
 
 class KubernetesSegment(Segment):
 


### PR DESCRIPTION
assume module is installed via python3 pip

closes #7 