### PR TITLE
Fixes for Python 3 and a minor display improvement

### DIFF
--- a/powerline_kubernetes/segments.py
+++ b/powerline_kubernetes/segments.py
@@ -1,13 +1,25 @@
-# vim:fileencoding=utf-8:noet
 from powerline.segments import Segment, with_docstring
-from kubernetes import K8sConfig
+
+import yaml
+# This is to prevent a warning about unsafe loads because kubernetes_py uses yaml.load instead of yaml.safe_load
+yaml.warnings({'YAMLLoadWarning': False})
+try:
+    from kubernetes_py import K8sConfig
+except ImportError:
+    # try the old name
+    from kubernetes import K8sConfig
 
 class KubernetesSegment(Segment):
 
-    def build_segments(self,context, namespace):
+    def build_segments(self, context, namespace):
+        if namespace=='default':
+            display_format = context
+        else:
+            display_format = '%s - %s' % (context, namespace)
+
         segments = [
             {'contents': u'\U00002388 ', 'highlight_groups': ['kubernetes'], 'divider_highlight_group': 'kubernetes:divider'},
-            {'contents': '%s - %s' % (context, namespace), 'highlight_groups': ['kubernetes'], 'divider_highlight_group': 'kubernetes:divider'},
+            {'contents': display_format, 'highlight_groups': ['kubernetes'], 'divider_highlight_group': 'kubernetes:divider'},
         ]
         return segments
 


### PR DESCRIPTION
Made the 'default' namespace not print on the context line since it takes up a lot of valuable room.
Added support for more modern versions of kubernetes_py.
Fixed a warning issue caused by kubernetes_py using yaml.load instead of yaml.safe_load which ends up printing on every load without suppressing the error.  I'm submitting a PR for that to kubernetes_py as well to fix it.