### PR TITLE
Allow for unset namespace values; fix deprecated PyYAML call

### DIFF
--- a/powerline_kubernetes/segments.py
+++ b/powerline_kubernetes/segments.py
@@ -19,7 +19,7 @@ class KubernetesSegment(Segment):
         }
 
     def build_segments(self, context, namespace):
-        alert = (namespace in self.alerts or context + ':' + namespace in self.alerts)
+        alert = (context in self.alerts or namespace in self.alerts or context + ':' + namespace in self.alerts)
         segments = []
 
         if self.show_cluster:
@@ -88,6 +88,11 @@ class KubernetesSegment(Segment):
         except Exception as e:
             pl.error(e)
             return
+        try:
+            namespace = ctx['namespace']
+        except KeyError:
+            namespace = 'default'
+
 
         return self.build_segments(context, namespace)
 

--- a/powerline_kubernetes/segments.py
+++ b/powerline_kubernetes/segments.py
@@ -51,7 +51,7 @@ class KubernetesSegment(Segment):
     @property
     def config(self):
         with open(self.conf_yaml, 'r') as f:
-            return yaml.load(f)
+            return yaml.load(f, Loader=yaml.FullLoader)
 
     def __init__(self):
         self.pl = None

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description      = 'A Powerline segment to show Kubernetes context',
     long_description = (pathlib.Path(__file__).parent / "README.md").read_text(),
     long_description_content_type="text/markdown",
-    version          = '1.1.0',
+    version          = '1.2.0',
     keywords         = 'powerline kubernetes context',
     license          = 'MIT',
     author           = 'Vincent De Smet',


### PR DESCRIPTION
I was getting errors on load (and the whole thing went sideways), as I was not typically setting the current namespace. This fixes that and allows for namespaces being set or unset. I also fixed a warning about a deprecated call to yaml.load withouth setting the Loader value.