### PR TITLE
Remove extraneous namespace access

### DIFF
--- a/powerline_kubernetes/segments.py
+++ b/powerline_kubernetes/segments.py
@@ -84,7 +84,6 @@ class KubernetesSegment(Segment):
             current_context = k8_loader.current_context
             ctx = current_context['context']
             context = current_context['name']
-            namespace = ctx['namespace']
         except Exception as e:
             pl.error(e)
             return

--- a/powerline_kubernetes/segments.py
+++ b/powerline_kubernetes/segments.py
@@ -59,6 +59,7 @@ class KubernetesSegment(Segment):
         self.show_cluster = None
         self.show_namespace = None
         self.show_default_namespace = None
+        self.kube_config_path = None
         self.alerts = []
 
     def __call__(
@@ -68,6 +69,7 @@ class KubernetesSegment(Segment):
             show_cluster=True,
             show_namespace=True,
             show_default_namespace=False,
+            kube_config_path=None,
             alerts=[],
             **kwargs
         ):
@@ -77,6 +79,7 @@ class KubernetesSegment(Segment):
         self.show_cluster = show_cluster
         self.show_namespace = show_namespace
         self.show_default_namespace = show_default_namespace
+        self.kube_config_path = kube_config_path or self.conf_yaml
         self.alerts = alerts
 
         try:


### PR DESCRIPTION
* This removes the unnecessary namespace access earlier in the logic
which causes the plugin to error out and return early before the
namespace try / except block is ever reached
* By removing the early access, we delegate the namespace handling to
the code following immediately after fetching the base context fields.