### PR TITLE
don't exit if no namespace

### DIFF
--- a/powerline_kubernetes/segments.py
+++ b/powerline_kubernetes/segments.py
@@ -84,7 +84,6 @@ class KubernetesSegment(Segment):
             current_context = k8_loader.current_context
             ctx = current_context['context']
             context = current_context['name']
-            namespace = ctx['namespace']
         except Exception as e:
             pl.error(e)
             return


### PR DESCRIPTION
kubernetes was not showing in segments if no namespace. This PR removes duplicate `namespace` value from the first `try` block in `__call__` method.